### PR TITLE
Add single playhead source of truth

### DIFF
--- a/crates/apps/looper/Sequencer/SequencerEngine/SequencerEngineController.swift
+++ b/crates/apps/looper/Sequencer/SequencerEngine/SequencerEngineController.swift
@@ -130,8 +130,11 @@ public class EngineController {
             store.timeInfo.tempo = tempo
             store.timeInfo.objectWillChange.send()
         }
+        if store.isPlaying != playhead.is_playing {
+            store.isPlaying = playhead.is_playing
+        }
 
-      DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .milliseconds(16)), qos: .userInitiated) {
+        DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .milliseconds(16)), qos: .userInitiated) {
             self.flushPollInfo()
         }
     }

--- a/crates/apps/looper/Sequencer/SequencerUI/Sources/SequencerUI/store/Store.swift
+++ b/crates/apps/looper/Sequencer/SequencerUI/Sources/SequencerUI/store/Store.swift
@@ -48,10 +48,10 @@ public class Store: ObservableObject {
     )
     public let processorMetrics = ProcessorMetrics()
     public let midi = MIDIMappingState()
+    @Published public var isPlaying: Bool = false
 
     @Published var selectedTrack: Int = 1
     @Published var selectedTab: TabValue = .source
-    @Published var isPlaying: Bool = false
     @Published var midiMappingActive = false
     let parameterLockStore = ParameterLockStore()
 

--- a/crates/apps/looper/looper-processor/src/c_api/mod.rs
+++ b/crates/apps/looper/looper-processor/src/c_api/mod.rs
@@ -283,6 +283,7 @@ pub struct CTimeInfo {
     position_beats: f64,
     // -1 means none
     tempo: f64, // -1 means none
+    is_playing: bool,
 }
 
 #[no_mangle]
@@ -477,6 +478,7 @@ pub unsafe extern "C" fn looper_engine__get_playhead_position(
         position_samples: time_info.position_samples(),
         position_beats: time_info.position_beats().unwrap_or(-1.0),
         tempo: time_info.tempo().unwrap_or(-1.0),
+        is_playing: time_info.is_playing(),
     }
 }
 

--- a/crates/apps/looper/looper-processor/src/multi_track_looper/mod.rs
+++ b/crates/apps/looper/looper-processor/src/multi_track_looper/mod.rs
@@ -32,6 +32,7 @@ use crate::multi_track_looper::lfo_processor::LFOHandle;
 use crate::multi_track_looper::midi_store::MidiStoreHandle;
 use crate::multi_track_looper::scene_state::SceneHandle;
 use crate::processor::handle::{LooperState, ToggleRecordingResult};
+use crate::time_info_provider::TimeInfoMetronomePlayhead;
 use crate::{LooperOptions, QuantizeMode, TimeInfoProvider, TimeInfoProviderImpl};
 
 pub(crate) mod allocator;
@@ -639,7 +640,9 @@ impl MultiTrackLooper {
             .map(|_| looper_voice::build_voice_processor(&options, &time_info_provider))
             .collect();
 
-        let metronome = metronome::MetronomeProcessor::new();
+        let metronome = metronome::MetronomeProcessor::new(TimeInfoMetronomePlayhead(
+            time_info_provider.clone(),
+        ));
         let metronome_handle = metronome.handle().clone();
         metronome_handle.set_is_playing(false);
         metronome_handle.set_volume(0.7);
@@ -701,7 +704,7 @@ impl MultiTrackLooper {
 
     fn build_audio_graph(
         processors: Vec<VoiceProcessors>,
-        metronome: MetronomeProcessor,
+        metronome: MetronomeProcessor<TimeInfoMetronomePlayhead>,
     ) -> AudioProcessorGraph {
         let mut graph = AudioProcessorGraph::default();
         let metronome_idx = graph.add_node(NodeType::Buffer(Box::new(metronome)));

--- a/crates/apps/looper/looper-processor/src/multi_track_looper/mod.rs
+++ b/crates/apps/looper/looper-processor/src/multi_track_looper/mod.rs
@@ -107,7 +107,7 @@ impl MultiTrackLooperHandle {
 
                 let parameters = handle.user_parameters();
                 let tempo_control = parameters.get(ParameterId::ParameterIdQuantization(
-                    QuantizationParameter::QuantizationParameterQuantizeMode,
+                    QuantizationParameter::QuantizationParameterTempoControl,
                 ));
 
                 if was_empty
@@ -518,7 +518,11 @@ impl MultiTrackLooperHandle {
 
     pub fn toggle_playback(&self, looper_id: LooperId) {
         if let Some(handle) = self.voices.get(looper_id.0) {
-            handle.looper().toggle_playback();
+            // TODO: We might want to stop the playhead
+            // Depending on whether there are other loopers playing
+            if handle.looper().toggle_playback() {
+                self.play();
+            }
         }
     }
 

--- a/crates/apps/looper/looper-processor/src/processor/handle/mod.rs
+++ b/crates/apps/looper/looper-processor/src/processor/handle/mod.rs
@@ -219,7 +219,8 @@ impl LooperHandle {
         self.end_offset.get() * self.length.get() as f32
     }
 
-    pub fn toggle_playback(&self) {
+    /// Toggle playback. Return true if the looper is playing after this.
+    pub fn toggle_playback(&self) -> bool {
         let old_state = self.state.get();
         if old_state == LooperState::Playing
             || old_state == LooperState::Recording
@@ -227,8 +228,10 @@ impl LooperHandle {
         {
             self.stop_recording_allocating_loop();
             self.pause();
+            false
         } else {
             self.play();
+            true
         }
     }
 
@@ -286,15 +289,17 @@ impl LooperHandle {
     }
 
     pub fn play(&self) {
-        // TODO: Looper should only affect time_info_provider if it's the master
-        self.time_info_provider.play();
+        if self.tick_time.get() {
+            self.time_info_provider.play();
+        }
         self.state.set(LooperState::Playing);
         self.cursor.set(self.get_start_samples());
     }
 
     pub fn pause(&self) {
-        // TODO: Looper should only affect time_info_provider if it's the master
-        self.time_info_provider.pause();
+        if self.tick_time.get() {
+            self.time_info_provider.pause();
+        }
         self.state.set(LooperState::Paused);
     }
 

--- a/crates/apps/looper/looper-processor/src/time_info_provider/mod.rs
+++ b/crates/apps/looper/looper-processor/src/time_info_provider/mod.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use derive_builder::Builder;
@@ -8,6 +9,7 @@ pub use audio_processor_standalone::standalone_vst::vst::plugin::HostCallback;
 #[cfg(not(target_os = "ios"))]
 use audio_processor_standalone::{standalone_vst::vst, standalone_vst::vst::host::Host};
 use augmented_playhead::{PlayHead, PlayHeadOptions};
+use metronome::MetronomePlayhead;
 
 #[cfg(target_os = "ios")]
 pub type HostCallback = ();
@@ -125,6 +127,14 @@ impl TimeInfoProviderImpl {
                 .tempo()
                 .map(|_| self.playhead.position_beats()),
         }
+    }
+}
+
+pub struct TimeInfoMetronomePlayhead(pub audio_garbage_collector::Shared<TimeInfoProviderImpl>);
+
+impl MetronomePlayhead for TimeInfoMetronomePlayhead {
+    fn position_beats(&self) -> f64 {
+        self.0.playhead().position_beats()
     }
 }
 

--- a/crates/apps/metronome/src/api/state.rs
+++ b/crates/apps/metronome/src/api/state.rs
@@ -28,7 +28,7 @@ unsafe impl Send for State {}
 
 impl State {
     pub fn new() -> Self {
-        let processor = MetronomeProcessor::new();
+        let processor = MetronomeProcessor::default();
         let processor_handle = processor.handle().clone();
         processor_handle.set_is_playing(false);
         let app = StandaloneAudioOnlyProcessor::new(


### PR DESCRIPTION
Metronome & looper refer to the same playhead state when on the sequencer app.

Metronome app is unchanged and provides its own master tempo.