### PR TITLE
fix unsound Sync impl for atomic_queue::Queue

### DIFF
--- a/crates/augmented/data/atomic-queue/src/lib.rs
+++ b/crates/augmented/data/atomic-queue/src/lib.rs
@@ -89,7 +89,7 @@ pub struct Queue<T> {
 }
 
 unsafe impl<T: Send> Send for Queue<T> {}
-unsafe impl<T> Sync for Queue<T> {}
+unsafe impl<T: Send> Sync for Queue<T> {}
 
 /// Alias for `Queue::new`, creates a new bounded `MPMC` queue with the given capacity.
 ///


### PR DESCRIPTION
This is technically a breaking change.

The current `impl<T> Sync for Queue<T>` impl is unsound and requires a `T: Send` bound.
This is because `Sync` allows sharing a `&Queue<T>` across threads (`T: Sync -> &T: Send`). Since you can remove elements from the queue with just a shared reference, it is possible to push a `!Send` type onto the queue, and pop it off on a different thread, which is unsound.

```rust
use atomic_queue::Queue;
use std::rc::Rc;
use std::thread;

fn main() {
    let queue = Queue::<Rc<i32>>::new(1);

    let not_send = Rc::new(0);
    queue.push(not_send);

    // since Queue: Sync, &Queue is Send
    let queue_ref = &queue;
    
    thread::scope(|scope| {
        scope.spawn(move || {
            let q = queue_ref;
            let oops = q.pop().unwrap();
            // oh no! we moved an Rc across threads :(
        });
    });
}
```